### PR TITLE
Add in the base disable Jetpack modules to core.

### DIFF
--- a/inc/classes/Core.php
+++ b/inc/classes/Core.php
@@ -28,6 +28,9 @@ class Core {
 		// '\RKV\Utilities\FSE\Category_Post_Template',
 		// '\RKV\Utilities\FSE\Lock_Down',
 		// '\RKV\Utilities\FSE\Reset_To_Theme',
+		
+		// // Jetpack.
+		'\RKV\Utilities\Jetpack\Modules',
 
 		// // Post Types.
 		'\RKV\Utilities\Post_Type\CTAs',

--- a/inc/classes/Jetpack/Modules.php
+++ b/inc/classes/Jetpack/Modules.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Disable Jetpack Modules.
+ * 
+ * @package rkv-theme
+ */
+ 
+namespace RKV\Utilities\Jetpack;
+
+/**
+ * Class to manage Jetpack modules.
+ */
+class Modules {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'jetpack_get_available_modules', [ $this, 'disable_modules' ] );
+	}
+
+	/**
+	 * Disable specific Jetpack modules.
+	 *
+	 * @param array $modules Array of active Jetpack modules.
+	 * @return array Modified array of active Jetpack modules.
+	 */
+	public function disable_modules( $modules ) {
+		$modules_to_disable = [
+			'contact-form',
+		];
+		
+		foreach ( $modules_to_disable as $module ) {
+			unset( $modules[ $module ] );
+		}
+
+		return $modules;
+	}
+}

--- a/inc/classes/Jetpack/Modules.php
+++ b/inc/classes/Jetpack/Modules.php
@@ -27,7 +27,23 @@ class Modules {
 	 */
 	public function disable_modules( $modules ) {
 		$modules_to_disable = [
+			'blaze',
+			'comments',
+			'comment-likes',
 			'contact-form',
+			'copy-post',
+			'google-fonts',
+			'gravatar-hovercards',
+			'latex',
+			'likes',
+			'monitor',
+			'notes',
+			'post-list',
+			'seo-tools',
+			'sitemaps',
+			'subscriptions',
+			'widgets',
+			'wordads',
 		];
 		
 		foreach ( $modules_to_disable as $module ) {

--- a/inc/classes/Jetpack/Modules.php
+++ b/inc/classes/Jetpack/Modules.php
@@ -42,6 +42,7 @@ class Modules {
 			'seo-tools',
 			'sitemaps',
 			'subscriptions',
+			'vaultpress',
 			'widgets',
 			'wordads',
 		];


### PR DESCRIPTION
## Description
https://app.asana.com/1/3796121588250/project/1200941589704138/task/1212928931114605?focus=true

Adds `RKV\Utilities\Jetpack\Modules`. This just disables the `contact-form` module.

## Testing Details

***
### ℹ️ ACCEPTANCE CRITERIA
 Please verify that the PR fulfills these requirements
***

* **Should this PR be attached to a milestone?**

* **Does this code complete work on an issue?**
  - [ ] ✔️ Yes:
  - [ ] No, this is a hotfix or part of a larger feature

* **The impact of this code is**
  - [ ] **⣀** minimal
  - [ ] **⣇** medium
  - [ ] **⣿** large

* **Were any new tests?**
  - [ ] 🧪 Yes, new tests have been added
  - [ ] No, our existing tests cover this feature

* **Do docs need to be updated? If yes, which docs?**
  * Add supporting docs here
   - [ ] No doc updates were needed

* **What types of testing will this need?**
  - [ ] Regression Tests
  - [ ] Accessibility Tests
  - [ ] Manual Verification
