### PR TITLE
add disable comments utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
 ![Core Plugin](./rkv-core.jpg "Logo Title Text 1")
 
-
 A collection of utilities, helpers and best practices at the foundation of what we do.
+
+## Guides
+- [Cache](docs/guides/Cache.md)
+- [Comments](docs/guides/Comments.md)
+- [Post Types](docs/guides/Post_Type.md)
+
+## Philosophy
+- [Code Collaboration](docs/philosophy/code-collaboration.md)
+
+## Contributing
+- [Code of Conduct](docs/contributing/code-of-conduct.md)
+- [Contributing Guidelines](docs/contributing/contributing-guidelines.md)
+- 

--- a/docs/guides/Comments.md
+++ b/docs/guides/Comments.md
@@ -1,0 +1,7 @@
+# Disable Comments
+Comments are disabled by default. Most of our clients do not use comments. If comments are required, add:
+```
+add_filter( 'rkv_disable_comments', '__return_false' );
+```
+
+The disable comments utility hides the discussion options, meta, and and anything else related to comments, but if the template uses the comment_form or comments template parts, this may still show some indication that comments are closed. To completely remove any reference to comments, remove those template elements.

--- a/inc/classes/Comments/Disable.php
+++ b/inc/classes/Comments/Disable.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * The Disable comments class.
+ *
+ * @package rkv-utilities
+ */
+
+namespace RKV\Utilities\Comments;
+
+/**
+ * Completely removes comments.
+ */
+class Disable {
+
+	/**
+	 * Adds the filters and actions required to disable comments
+	 */
+	public function run() {
+		$disable_comments = apply_filters( 'rkv_disable_comments', true );
+
+		if ( ! $disable_comments ) {
+			return;
+		}
+
+		add_action( 'widgets_init', array( $this, 'disable_rc_widget' ) );
+		add_filter( 'wp_headers', array( $this, 'filter_wp_headers' ) );
+		add_action( 'template_redirect', array( $this, 'filter_query' ), 9 );
+
+		add_action( 'template_redirect', array( $this, 'filter_admin_bar' ) );
+		add_action( 'admin_init', array( $this, 'filter_admin_bar' ) );
+
+		add_action( 'wp_loaded', array( $this, 'init_wploaded_filters' ) );
+	}
+
+	/**
+	 * Additional filters to disable comments.
+	 */
+	public function init_wploaded_filters() {
+		$post_types = get_post_types( array( 'public' => true ) );
+		if ( ! empty( $post_types ) ) {
+			foreach ( $post_types as $type ) {
+				// we need to know what native support was for later.
+				if ( post_type_supports( $type, 'comments' ) ) {
+					remove_post_type_support( $type, 'comments' );
+					remove_post_type_support( $type, 'trackbacks' );
+				}
+			}
+		}
+
+		add_filter( 'comments_array', '__return_empty_array', 20, 2 );
+		add_filter( 'comments_open', '__return_false', 20, 2 );
+		add_filter( 'pings_open', '__return_false', 20, 2 );
+
+		add_action( 'admin_menu', array( $this, 'filter_admin_menu' ), 9999 );
+		add_action( 'admin_print_styles-index.php', array( $this, 'admin_css' ) );
+		add_action( 'admin_print_styles-profile.php', array( $this, 'admin_css' ) );
+		add_action( 'wp_dashboard_setup', array( $this, 'filter_dashboard' ) );
+		add_filter( 'pre_option_default_pingback_flag', '__return_zero' );
+
+		add_action( 'template_redirect', array( $this, 'check_comment_template' ) );
+		add_filter( 'feed_links_show_comments_feed', '__return_false' );
+	}
+
+	/**
+	 * Ensure scripts/header output is disabled.
+	 */
+	public function check_comment_template() {
+		if ( is_singular() ) {
+			wp_deregister_script( 'comment-reply' );
+
+			remove_action( 'wp_head', 'feed_links_extra', 3 );
+		}
+	}
+
+	/**
+	 * Remove the X-Pingback HTTP header
+	 *
+	 * @param array $headers The headers.
+	 *
+	 * @return array The headers.
+	 */
+	public function filter_wp_headers( $headers ) {
+		unset( $headers['X-Pingback'] );
+		return $headers;
+	}
+
+	/**
+	 * Issue a 403 for all comment feed requests.
+	 */
+	public function filter_query() {
+		if ( is_comment_feed() ) {
+			wp_die( esc_html__( 'Comments are closed.', 'rkv-utilities' ), '', array( 'response' => 403 ) );
+		}
+	}
+
+	/**
+	 * Remove comment links from the admin bar.
+	 */
+	public function filter_admin_bar() {
+		if ( is_admin_bar_showing() ) {
+			// Remove comments links from admin bar.
+			remove_action( 'admin_bar_menu', 'wp_admin_bar_comments_menu', 60 );
+		}
+	}
+
+	/**
+	 * Removes the comment pages.
+	 */
+	public function filter_admin_menu() {
+		global $pagenow;
+
+		if ( in_array( $pagenow, array( 'comment.php', 'edit-comments.php', 'options-discussion.php' ), true ) ) {
+			wp_die( esc_html__( 'Comments are closed.', 'rkv-utilities' ), '', array( 'response' => 403 ) );
+		}
+
+		remove_menu_page( 'edit-comments.php' );
+		remove_submenu_page( 'options-general.php', 'options-discussion.php' );
+	}
+
+	/**
+	 * Removes the comments dashboard widget.
+	 */
+	public function filter_dashboard() {
+		remove_meta_box( 'dashboard_recent_comments', 'dashboard', 'normal' );
+	}
+
+	/**
+	 * Hides comment elements that may have missed removal.
+	 */
+	public function admin_css() {
+		echo '<style>
+			#dashboard_right_now .comment-count,
+			#dashboard_right_now .comment-mod-count,
+			#latest-comments,
+			#welcome-panel .welcome-comments,
+			.user-comment-shortcuts-wrap {
+				display: none !important;
+			}
+		</style>';
+	}
+
+	/**
+	 * Removes the recent comments widget.
+	 */
+	public function disable_rc_widget() {
+		unregister_widget( 'WP_Widget_Recent_Comments' );
+	}
+}

--- a/inc/classes/Comments/Disable.test.php
+++ b/inc/classes/Comments/Disable.test.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Unit tests for Disable class.
+ *
+ * @package rkv-utilities
+ */
+
+namespace RKV\Utilities\Comments;
+
+use WP_Mock\Tools\TestCase;
+
+/**
+ * Class Disable_Test
+ *
+ * @covers \RKV\Utilities\Comments\Disable
+ */
+class Disable_Test extends TestCase {
+
+	/**
+	 * Set up before class.
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass(): void {
+		require_once dirname( __DIR__ ) . '/Disable.php';
+	}
+
+	/**
+	 * Set up test environment.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		// Initialize WP_Mock.
+		WP_Mock::setUp();
+	}
+
+	/**
+	 * Tear down test environment.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		// Tear down WP_Mock.
+		WP_Mock::tearDown();
+	}
+
+	/**
+	 * Test constructor.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$instance = new Disable();
+		$this->assertInstanceOf( Disable::class, $instance );
+	}
+
+	/**
+	 * Test actions added.
+	 *
+	 * @return void
+	 */
+	public function test_actions_added() {
+		$instance = new Disable();
+		\WP_Mock::expectActionAdded( 'widgets_init', array( $instance, 'disable_rc_widget' ) );
+
+		$instance->init();
+		WP_Mock::assertHooksAdded();
+	}
+
+	/**
+	 * Test filter_wp_headers method.
+	 *
+	 * @return void
+	 */
+	public function test_filter_wp_headers() {
+		$instance         = new Disable();
+		$filtered_headers = $instance->filter_wp_headers(
+			[
+				'X-Pingback' => 'http://example.com/xmlrpc.php',
+				'Link'       => '<http://example.com/wp-json/>; rel="https://api.w.org/"',
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'X-Pingback', $filtered_headers );
+	}
+}

--- a/inc/classes/Core.php
+++ b/inc/classes/Core.php
@@ -22,6 +22,8 @@ class Core {
 	 */
 	private $classes = [
 		// More to come.
+		// Comments.
+		'\RKV\Utilities\Comments\Disable',
 
 
 		// FSE.


### PR DESCRIPTION
## Description
Adds the disable comments utility. 

This was originally built as a standalone RKV plugin, but seeing as we use it on almost every client project, we're rolling this into core.

Docs were added and the readme.md was updated with a table of contents linking to various docs. 
